### PR TITLE
used closest(span) and delete whole span

### DIFF
--- a/dict.js
+++ b/dict.js
@@ -1,7 +1,7 @@
 var dict = {
   "phrases": ["and this is what happen", "character are you", "how many of these", "real or fake", "are you based on", "can you identify", "can you guess", "do you actually", "which celebrity", "everything you need to know", "how well do you know", "this is what happen", "you won't believe what happen", "guess what happen", "jennifer lawrence", "man bun", "everyday life", "wants you to find out", "totally unexpected", "reasons why", "watch this guy", "watch this girl", "hear one man", "hear one woman", "until one man", "until one woman", "the result is", "reasons to love", "reasons to hate", "find out what", "woah!", "awesome!", "check out these", "look at this", "look at these", "can you guess", "who is your", "what is your", "are you", "can we guess", "how well do you", "garunteed to make you", "insane ways", "zodiac", "should you get", "you can't miss", "don't miss", "watch this if"],
   "number_phrases": ["things", "times", "ways", "weird", "pictures", "people", "songs", "signs", "reasons", "celeb", "celebrity", "awkward", "disney", "situations", "vintage", "websites", "questions", "thoughts", "ideas", "secrets", "tricks", "books", "confessions"],
-  "blocked_urls": ["bzfd.it", "buzzfeed.com", "clickhole.com", "u.pw", "upworthy.com"]
+  "blocked_urls": ["bzfd.it", "buzzfeed.com", "clickhole.com", "u.pw", "upworthy.com", "on.mtv.com"]
 };
 
 var newTitle = "Junk article.";

--- a/main.js
+++ b/main.js
@@ -36,7 +36,8 @@ function changeFacebookLink(_this) {
   if (uilinkSubtle || UFINoWrap || UFIShareLink || UFICommentLink || UFICommentLike) {
 
     return;
-  } else {
+  } 
+   else {
 
     changeLink(_this);
   }
@@ -65,6 +66,7 @@ function changeLink(_this) {
   title = $(_this).text();
   title = title.trim().toLowerCase();
 
+
   if (title) {
     dict["phrases"].forEach(function(phrase) {
       if (title.indexOf(phrase) > -1) {
@@ -87,6 +89,7 @@ function changeLink(_this) {
     dict["blocked_urls"].forEach(function(url) {
       if (link.indexOf(url) > -1) {
         $(_this).text(newTitle);
+        $(_this).closest('span').remove();
         changed = true;
       }
     });


### PR DESCRIPTION
I think this will do the trick on the double link thing.  when it fins
one it now just goes to the parent <span> tag and deletes it.  If we
wanna replace it with something might need to add a line of code.
